### PR TITLE
add curios support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     forge "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     //modImplementation fileTree(include: ['*.jar'], dir: 'libs')
     modImplementation("curse.maven:ic2_classic-242942:4041302")
+    modImplementation("curse.maven:curios-309927:3871347")
     modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-forge:${rootProject.rei_version}"
     modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-plugin-compatibilities-forge:9.1.530"
     /*deobfProvided "mezz.jei:jei_${mc_version}:${jei_version}:api"

--- a/src/main/java/trinsdar/gravisuit/mixin/CurioModuleMixin.java
+++ b/src/main/java/trinsdar/gravisuit/mixin/CurioModuleMixin.java
@@ -12,6 +12,6 @@ import trinsdar.gravisuit.util.Registry;
 public abstract class CurioModuleMixin {
 	@Inject(method = "postInit", at = @At("TAIL"), remap = false)
 	private void injectPostInit(CallbackInfo info) {
-		IC2Tags.registerSimpleTag("curios", "back", Registry.ADVANCED_ELECTRIC_JETPACK, Registry.ADVANCED_NUCLEAR_JETPACK, Registry.GRAVITATION_JETPACK, Registry.NUCLEAR_GRAVITATION_JETPACK);
+		IC2Tags.registerSimpleTag("curios", "back", Registry.ADVANCED_ELECTRIC_JETPACK, Registry.ADVANCED_NUCLEAR_JETPACK, Registry.GRAVITATION_JETPACK, Registry.NUCLEAR_GRAVITATION_JETPACK, Registry.ADVANCED_LAPPACK, Registry.ULTIMATE_LAPPACK);
 	}
 }

--- a/src/main/java/trinsdar/gravisuit/mixin/CurioModuleMixin.java
+++ b/src/main/java/trinsdar/gravisuit/mixin/CurioModuleMixin.java
@@ -1,0 +1,17 @@
+package trinsdar.gravisuit.mixin;
+
+import ic2.core.platform.registries.IC2Tags;
+import ic2.curioplugin.CurioModule;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import trinsdar.gravisuit.util.Registry;
+
+@Mixin(CurioModule.class)
+public abstract class CurioModuleMixin {
+	@Inject(method = "postInit", at = @At("TAIL"), remap = false)
+	private void injectPostInit(CallbackInfo info) {
+		IC2Tags.registerSimpleTag("curios", "back", Registry.ADVANCED_ELECTRIC_JETPACK, Registry.ADVANCED_NUCLEAR_JETPACK, Registry.GRAVITATION_JETPACK, Registry.NUCLEAR_GRAVITATION_JETPACK);
+	}
+}

--- a/src/main/java/trinsdar/gravisuit/mixin/CurioPluginMixin.java
+++ b/src/main/java/trinsdar/gravisuit/mixin/CurioPluginMixin.java
@@ -1,0 +1,33 @@
+package trinsdar.gravisuit.mixin;
+
+import ic2.curioplugin.core.CurioPlugin;
+import ic2.curioplugin.modules.TickingCurio;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import top.theillusivec4.curios.api.SlotTypeMessage;
+import top.theillusivec4.curios.api.SlotTypePreset;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+import trinsdar.gravisuit.GravisuitClassic;
+import trinsdar.gravisuit.util.Registry;
+
+@Mixin(CurioPlugin.class)
+public abstract class CurioPluginMixin {
+	@Inject(method = "loadIMC", at = @At("TAIL"), remap = false)
+	private void injectLoadIMC(InterModEnqueueEvent mod, CallbackInfo info) {
+		InterModComms.sendTo(GravisuitClassic.MODID, "curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.BACK.getMessageBuilder().build());
+	}
+
+	@Inject(method = "createForItem", at = @At("TAIL"), remap = false, cancellable = true)
+	private void injectCreateForItem(ItemStack stack, CallbackInfoReturnable<ICurio> info) {
+		Item i = stack.getItem();
+
+		if (i == Registry.ADVANCED_ELECTRIC_JETPACK || i == Registry.ADVANCED_NUCLEAR_JETPACK || i == Registry.GRAVITATION_JETPACK || i == Registry.NUCLEAR_GRAVITATION_JETPACK) info.setReturnValue(new TickingCurio(stack, false, true, true));
+	}
+}

--- a/src/main/java/trinsdar/gravisuit/mixin/CurioPluginMixin.java
+++ b/src/main/java/trinsdar/gravisuit/mixin/CurioPluginMixin.java
@@ -29,5 +29,6 @@ public abstract class CurioPluginMixin {
 		Item i = stack.getItem();
 
 		if (i == Registry.ADVANCED_ELECTRIC_JETPACK || i == Registry.ADVANCED_NUCLEAR_JETPACK || i == Registry.GRAVITATION_JETPACK || i == Registry.NUCLEAR_GRAVITATION_JETPACK) info.setReturnValue(new TickingCurio(stack, false, true, true));
+		if (i == Registry.ADVANCED_LAPPACK || i == Registry.ULTIMATE_LAPPACK) info.setReturnValue(new TickingCurio(stack, false, false, true));
 	}
 }

--- a/src/main/resources/gravisuit.mixins.json
+++ b/src/main/resources/gravisuit.mixins.json
@@ -11,7 +11,9 @@
     "CompactedNuclearJetpackMixin",
     "IC2ElectricJetpackBaseMixin",
     "IC2ModularElectricArmorMixin",
-    "ElectricPackArmorMixin"
+    "ElectricPackArmorMixin",
+    "CurioPluginMixin",
+    "CurioModuleMixin"
   ],
   "minVersion": "0.8"
 }


### PR DESCRIPTION
closes https://github.com/Trins-mods/Gravisuit-Classic-Edition/issues/32

This adds curios support for gravisuit jetpack and lappack variants.

This pr completely piggybacks on ic2 classics curios support, which means, if that module is disabled in the ic2 classic config, this here will also be disabled.

Technically the imc message requesting a back slot for curios is not needed, but as it won't hurt either, I included it here.
